### PR TITLE
#24 - Upgrade dependencies

### DIFF
--- a/dkpro-meta-core/pom.xml
+++ b/dkpro-meta-core/pom.xml
@@ -35,19 +35,19 @@
       <artifactId>commons-logging-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
+      <groupId>org.apache.groovy</groupId>
       <artifactId>groovy</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
+      <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-json</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
+      <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-xml</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.groovy</groupId>
+      <groupId>org.apache.groovy</groupId>
       <artifactId>groovy-templates</artifactId>
     </dependency>
     <dependency>

--- a/dkpro-meta-core/src/main/groovy/org/dkpro/meta/core/MetadataAggregator.groovy
+++ b/dkpro-meta-core/src/main/groovy/org/dkpro/meta/core/MetadataAggregator.groovy
@@ -22,7 +22,9 @@ import static groovy.io.FileType.FILES;
 import groovy.json.*;
 import groovy.text.XmlTemplateEngine;
 import groovy.transform.Field;
-import groovy.util.XmlParser;
+import groovy.xml.XmlParser;
+import groovy.xml.XmlSlurper
+
 import org.dkpro.meta.core.maven.ContextHolder
 import org.dkpro.meta.core.model.FormatModel;
 import org.dkpro.meta.core.model.EngineModel;

--- a/dkpro-meta-example-galaxy/pom.xml
+++ b/dkpro-meta-example-galaxy/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.9.2</version>
+      <version>1.15.4</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.apache.ivy</groupId>
       <artifactId>ivy</artifactId>
-      <version>2.3.0</version>
+      <version>2.5.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/dkpro-meta-example-galaxy/src/main/groovy/org/dkpro/meta/example/galaxy/GalaxyToolBuilder.groovy
+++ b/dkpro-meta-example-galaxy/src/main/groovy/org/dkpro/meta/example/galaxy/GalaxyToolBuilder.groovy
@@ -22,7 +22,7 @@ import groovy.io.FileType;
 import groovy.json.*;
 import groovy.text.XmlTemplateEngine
 import groovy.transform.Field
-import groovy.util.XmlParser
+import groovy.xml.XmlParser
 import java.nio.file.Files
 import org.dkpro.meta.core.MetadataAggregator;
 import org.dkpro.meta.core.model.MetadataModel;

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.dkpro</groupId>
     <artifactId>dkpro-parent-pom</artifactId>
-    <version>25</version>
+    <version>29</version>
   </parent>
   <groupId>org.dkpro.meta</groupId>
   <artifactId>dkpro-meta</artifactId>
@@ -41,51 +41,6 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
-  <repositories>
-    <!-- For UIMA/uimaFIT SNAPSHOT -->
-    <!--
-      <repository>
-      <id>apache.snapshots</id>
-      <name>Apache Snapshot Repository</name>
-      <url>http://repository.apache.org/snapshots</url>
-      <releases>
-      <enabled>false</enabled>
-      </releases>
-      <snapshots>
-      <enabled>true</enabled>
-      </snapshots>
-      </repository>
-    -->
-    <!-- For DKPro Parent POM SNAPSHOT -->
-    <!--
-      <repository>
-      <id>ukp-oss-snapshots</id>
-      <url>http://zoidberg.ukp.informatik.tu-darmstadt.de/artifactory/public-snapshots</url>
-      <releases>
-      <enabled>false</enabled>
-      </releases>
-      <snapshots>
-      <enabled>true</enabled>
-      </snapshots>
-      </repository>
-    -->
-  </repositories>
-  <pluginRepositories>
-    <!-- For UIMA/uimaFIT SNAPSHOT maven plugin -->
-    <!--  
-    <pluginRepository>
-      <id>apache.snapshots</id>
-      <name>Apache Snapshot Repository</name>
-      <url>http://repository.apache.org/snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-    -->
-  </pluginRepositories>
   <mailingLists>
     <mailingList>
       <name>DKPro Core user mailing list</name>
@@ -107,19 +62,19 @@
     <url>https://github.com/dkpro/dkpro-meta/issues</url>
   </issueManagement>
   <scm>
-    <connection>scm:git:git://github.com/dkpro/dkpro-meta</connection>
-    <developerConnection>scm:git:git@github.com:dkpro/dkpro-meta.git</developerConnection>
+    <connection>scm:git:https://github.com/dkpro/dkpro-meta.git</connection>
+    <developerConnection>scm:git:https://github.com/dkpro/dkpro-meta.git</developerConnection>
     <url>https://github.com/dkpro/dkpro-meta</url>
     <tag>HEAD</tag>
   </scm>
   <properties>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
-    <uima.version>3.1.1</uima.version>
-    <uimafit.version>3.1.0</uimafit.version>
-    <uimafit.plugin.version>3.1.0</uimafit.plugin.version>
+    <uima.version>3.4.1</uima.version>
+    <uimafit.version>3.4.0</uimafit.version>
+    <uimafit.plugin.version>3.4.0</uimafit.plugin.version>
     <!-- The Spring version should be at least whatever uimaFIT requires -->
-    <spring.version>4.3.30.RELEASE</spring.version>
-    <groovy.version>3.0.7</groovy.version>
+    <spring.version>5.3.26</spring.version>
+    <groovy.version>4.0.11</groovy.version>
   </properties>
   <modules>
     <module>dkpro-meta-core</module>
@@ -135,7 +90,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.13.1</version>
+        <version>4.13.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.uima</groupId>
@@ -175,12 +130,12 @@
       <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
-        <version>1.27</version>
+        <version>1.33</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.8.0</version>
+        <version>2.11.0</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>
@@ -190,7 +145,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.11</version>
+        <version>3.12.0</version>
       </dependency>
       <dependency>
         <groupId>commons-configuration</groupId>
@@ -198,7 +153,7 @@
         <version>1.10</version>
       </dependency>
       <dependency>
-        <groupId>org.codehaus.groovy</groupId>
+        <groupId>org.apache.groovy</groupId>
         <artifactId>groovy-bom</artifactId>
         <version>${groovy.version}</version>
         <type>pom</type>
@@ -219,7 +174,7 @@
           <plugin>
             <groupId>org.codehaus.gmavenplus</groupId>
             <artifactId>gmavenplus-plugin</artifactId>
-            <version>1.6.3</version>
+            <version>2.1.0</version>
             <executions>
               <execution>
                 <id>build</id>
@@ -251,7 +206,7 @@
             </executions>
             <dependencies>
               <dependency>
-                <groupId>org.codehaus.groovy</groupId>
+                <groupId>org.apache.groovy</groupId>
                 <artifactId>groovy-all</artifactId>
                 <version>${groovy.version}</version>
                 <type>pom</type>


### PR DESCRIPTION
- DKPro Parent POM 25 -> 29
- UIMA Java SDK 3.1.1 -> 3.4.1
- uimaFIT 3.1.0 -> 3.4.0
- spring 4.0.11 -> 5.3.26
- groovy 3.0.7 -> 4.0.11
- junit 4.13.1 -> 4.13.2
- snakeyaml 1.27 -> 1.33
- commons-io 2.8.0 -> 2.11.0
- commons-lang3 3.11 -> 3.12.0
- gmavenplus-plugin 1.6.3 -> 2.1.0